### PR TITLE
chore(scripts): rename flastik -> flastik.py

### DIFF
--- a/scripts/flastik.py
+++ b/scripts/flastik.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
 
     # Building Website and collecting statics
     website.build(**options)
-    collect_static_files(**options)       
+    collect_static_files(**options)
 """
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rename scripts/flastik to scripts/flastik.py to follow Python filename conventions (enables editor tooling and direct execution). No functional changes.